### PR TITLE
Prevent overwrite of /etc/motd file

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/ssh-aliases
+++ b/saltstack/base/salt/prerequisites/usr/bin/ssh-aliases
@@ -8,8 +8,11 @@ debug() {
 
 create_motd() {
   debug "create_motd()"
+  FILENAME=/etc/motd
+  SIZE=$(du -sb $FILENAME | awk '{ print $1}')
+
+  if [ "$SIZE" -eq 0 ]; then
   cat > /etc/motd <<"EOF"
-cat /etc/motd
                     .-.._
               __  /`     '.
            .-'  `/   (   a \
@@ -22,6 +25,9 @@ cat /etc/motd
 EOF
   helper_desc >> /etc/motd
   echo >> /etc/motd
+  else
+    debug "motd already exists";
+  fi
 }
 
 create_motd_login() {


### PR DESCRIPTION
If the /etc/motd has content then do not overwrite with vendor motd. Necessary to allow for inclusion of customer required motd.